### PR TITLE
Add filter value properties with explicit types.

### DIFF
--- a/example/board/main.tf
+++ b/example/board/main.tf
@@ -30,7 +30,7 @@ data "honeycombio_query" "query" {
   filter {
     column = "app.tenant"
     op     = "="
-    value  = "ThatSpecialTenant"
+    value_string  = "ThatSpecialTenant"
   }
 }
 


### PR DESCRIPTION
As described in https://github.com/kvrhdn/terraform-provider-honeycombio/issues/27, the Honeycomb API currently fails to parse queries if a filter is sent with the wrong type in the JSON payload.

This PR adds new `value_*` options to the filter schema for each type in the Honeycomb API.
These properties are mutually exclusive with themselves and the original `value` field.


Feel free to either comment or edit @kvrhdn.
If you'd prefer to go with one of the other options enumerated in #27 that's fine too, just putting an option out there.

Fixes https://github.com/kvrhdn/terraform-provider-honeycombio/issues/27 