### PR TITLE
Formatting markdown documents to be less than 120 characters wide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 terraform-provider-honeycombio*
 
 coverage.txt
+
+.idea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,9 @@
 
 All contributions are welcome, whether they are technical in nature or not.
 
-Feel free to open a new issue to ask questions, discuss issues or propose enhancements. You can also chat with us on the **Honeycomb Pollinators** Slack in the **#terraform-provider** channel, you can find a direct link to request an invite in [Spread the Love: Appreciating Our Pollinators Community](https://www.honeycomb.io/blog/spread-the-love-appreciating-our-pollinators-community/).
+Feel free to open a new issue to ask questions, discuss issues or propose enhancements. You can also chat with us on the 
+**Honeycomb Pollinators** Slack in the **#terraform-provider** channel, you can find a direct link to request an invite 
+in [Spread the Love: Appreciating Our Pollinators Community](https://www.honeycomb.io/blog/spread-the-love-appreciating-our-pollinators-community/).
 
 The rest of this document describes how to get started developing on this repository.
 
@@ -10,13 +12,20 @@ The rest of this document describes how to get started developing on this reposi
 
 ### Relevant documentation
 
-Hashicorp has a lot of documentation on creating custom Terraform providers categorized under [Extending Terraform](https://www.terraform.io/docs/extend/index.html). This might help when getting started, but are not a pre-requisite to contribute. Feel free to just open an issue and we can guide you along the way.
+Hashicorp has a lot of documentation on creating custom Terraform providers categorized under 
+[Extending Terraform](https://www.terraform.io/docs/extend/index.html). This might help when getting started, but are 
+not a pre-requisite to contribute. Feel free to just open an issue and we can guide you along the way.
 
-We use [go-honeycombio](https://github.com/kvrhdn/go-honeycombio) to call the various Honeycomb APIs. While this takes care of most implementation details, it can still be valuable to check out [the official documentation of the APIs](https://docs.honeycomb.io/api/). The provider can only do as much as the APIs allow.
+We use [go-honeycombio](https://github.com/kvrhdn/go-honeycombio) to call the various Honeycomb APIs. While this takes 
+care of most implementation details, it can still be valuable to check out 
+[the official documentation of the APIs](https://docs.honeycomb.io/api/). The provider can only do as much as the APIs 
+allow.
 
 ### What's in progress and what's next?
 
-We maintain [an activity board](https://github.com/kvrhdn/terraform-provider-honeycombio/projects/1) with all the work that is currently being worked on and/or considered. Hopefully this can give a sense of what is next to come. The board is intended to create overview across the project, it's not a strict plan of action.
+We maintain [an activity board](https://github.com/kvrhdn/terraform-provider-honeycombio/projects/1) with all the work 
+that is currently being worked on and/or considered. Hopefully this can give a sense of what is next to come. The board 
+is intended to create overview across the project, it's not a strict plan of action.
 
 ## Contributing changes
 
@@ -26,11 +35,14 @@ Hashicorp has a tool to preview documentation. Visit [registry.terraform.io/tool
 
 ### Running the test
 
-Most of the tests are acceptance tests, which will call real APIs. To run the tests you'll need to have access to a Honeycomb account. If not, you can create a new free team.
+Most of the tests are acceptance tests, which will call real APIs. To run the tests you'll need to have access to a 
+Honeycomb account. If not, you can create a new free team.
 
-First, **create an API key**. Initially you'll have to check all permissions, but _Send Events_ and _Create Datasets_ can be disabled once setup is done.
+First, **create an API key**. Initially you'll have to check all permissions, but _Send Events_ and _Create Datasets_ 
+can be disabled once setup is done.
 
-Next, **initialize the dataset by sending a test event**. This will 1) create the dataset and 2) create columns that are used in the tests.  We need the following columns to exist: `duration_ms`, `trace.parent_id` and `app.tenant`.
+Next, **initialize the dataset by sending a test event**. This will 1) create the dataset and 2) create columns that 
+are used in the tests.  We need the following columns to exist: `duration_ms`, `trace.parent_id` and `app.tenant`.
 
 The easiest way to send an event is with [honeyvent](https://github.com/honeycombio/honeyvent):
 
@@ -58,13 +70,18 @@ With **Terraform 0.12** this is very straightforward:
 - copy the executable (named `terraform-provider-honeycombio`) into your working directory
 - run `terraform init`
 
-This is a bit more involved with **Terraform 0.13**: the provider has to be installed in one of the [local mirror directories](https://www.terraform.io/docs/commands/cli-config.html#implied-local-mirror-directories) using the [new filesysem structure](https://www.terraform.io/upgrade-guides/0-13.html#new-filesystem-layout-for-local-copies-of-providers). Additinally, the provider should have a version.
+This is a bit more involved with **Terraform 0.13**: the provider has to be installed in one of the 
+[local mirror directories](https://www.terraform.io/docs/commands/cli-config.html#implied-local-mirror-directories) 
+using the [new filesysem structure](https://www.terraform.io/upgrade-guides/0-13.html#new-filesystem-layout-for-local-copies-of-providers). 
+Additinally, the provider should have a version.
 
-For macOS, I've added the `install_macos` target in [`Makefile`](Makefile). Other OS's should be similar, feel free to add an additional target.
+For macOS, I've added the `install_macos` target in [`Makefile`](Makefile). Other OS's should be similar, feel free to 
+add an additional target.
 
 ### Enabling log output
 
-To print logs (including full dumps of requests and their responses), you have to set `TF_LOG` to at least `debug` and enable `HONEYCOMBIO_DEBUG` when running Terraform:
+To print logs (including full dumps of requests and their responses), you have to set `TF_LOG` to at least `debug` 
+and enable `HONEYCOMBIO_DEBUG` when running Terraform:
 
 ```sh
 TF_LOG=debug HONEYCOMBIO_DEBUG=true terraform apply
@@ -87,13 +104,15 @@ goimports -l -w .
 go mod tidy
 ```
 
-`goimports` will format the code like `gofmt` but will also fix imports. It can be installed with `go get golang.org/x/tools/cmd/goimports`.
+`goimports` will format the code like `gofmt` but will also fix imports. It can be installed with 
+`go get golang.org/x/tools/cmd/goimports`.
 
 Both commands should create no changes before a pull request can be merged.
 
 ### Run GitHub Actions in your fork
 
-If you fork the repository, you can also run the tests on GitHub Actions (for free since it's a public repository). Unfortunatly there is no mechanism to share secrets, so all runs will fail until the necessary secrets are configured.
+If you fork the repository, you can also run the tests on GitHub Actions (for free since it's a public repository). 
+Unfortunatly there is no mechanism to share secrets, so all runs will fail until the necessary secrets are configured.
 
 To properly setup the GitHub Actions, add the following secrets:
 
@@ -103,16 +122,21 @@ To properly setup the GitHub Actions, add the following secrets:
 
 ## Release procedure
 
-To release a new version of the Terraform provider a binary has to be built for a list of platforms ([more information](https://www.terraform.io/docs/registry/providers/publishing.html#creating-a-github-release)). This process is automated with GoReleaser and GitHub Actions.
+To release a new version of the Terraform provider a binary has to be built for a list of platforms 
+([more information](https://www.terraform.io/docs/registry/providers/publishing.html#creating-a-github-release)). This 
+process is automated with GoReleaser and GitHub Actions.
 
 - Create [a new release](https://github.com/kvrhdn/terraform-provider-honeycombio/releases/new)
 - The tag and release title should be a semantic version
-- To follow convention of other Terraform providers the description has the following sections (each section can be omitted if empty):
+- To follow convention of other Terraform providers the description has the following sections (each section can be 
+  omitted if empty):
 ```
 NOTES:
 FEATURES:
 ENHANCEMENTS:
 BUG FIXES:
 ```
-- After that tag has been created a GitHub Actions workflow Release will run and add binaries to the release (this workflow can run over 5 minutes)
-- Once the tag is created, the [Terraform Registry](https://registry.terraform.io/providers/kvrhdn/honeycombio/latest) should also list the new version
+- After that tag has been created a GitHub Actions workflow Release will run and add binaries to the release (this 
+  workflow can run over 5 minutes)
+- Once the tag is created, the [Terraform Registry](https://registry.terraform.io/providers/kvrhdn/honeycombio/latest) 
+  should also list the new version

--- a/README.md
+++ b/README.md
@@ -9,16 +9,21 @@ A Terraform provider for Honeycomb.io.
 
 📄 Check out [the documentation](https://registry.terraform.io/providers/kvrhdn/honeycombio/latest/docs)  
 🏗️ Examples can be found in [example/](example/)  
-❓ Questions? Feel free to create a new issue or find us on the **Honeycomb Pollinators** Slack, channel **#terraform-provider** (you can find a link to request an invite [here](https://www.honeycomb.io/blog/spread-the-love-appreciating-our-pollinators-community/))  
+❓ Questions? Feel free to create a new issue or find us on the **Honeycomb Pollinators** Slack, channel 
+**#terraform-provider** (you can find a link to request an invite [here](https://www.honeycomb.io/blog/spread-the-love-appreciating-our-pollinators-community/))  
 🔧 Want to contribute? Check out [CONTRIBUTING.md](./CONTRIBUTING.md)  
 
 ## Using the provider
 
-If you are using Terraform 0.13, you can install the provider directly from the [Terraform Registry](https://registry.terraform.io/providers/kvrhdn/honeycombio/latest). To use the provider with Terraform 0.12 you'll have to install the provider manually.
+If you are using Terraform 0.13, you can install the provider directly from the 
+[Terraform Registry](https://registry.terraform.io/providers/kvrhdn/honeycombio/latest). To use the provider with 
+Terraform 0.12 you'll have to install the provider manually.
 
 ### Terraform 0.13
 
-Add the following block in your Terraform config. For more information, refer to [Automatic installation of third-party providers](https://github.com/hashicorp/terraform/tree/guide-v0.13-beta/provider-sources#terraform-v013-beta-automatic-installation-of-third-party-providers). This will download the provider from the Terraform Registry:
+Add the following block in your Terraform config. For more information, refer to 
+[Automatic installation of third-party providers](https://github.com/hashicorp/terraform/tree/guide-v0.13-beta/provider-sources#terraform-v013-beta-automatic-installation-of-third-party-providers). 
+This will download the provider from the Terraform Registry:
 
 ```hcl
 terraform {
@@ -33,14 +38,17 @@ terraform {
 
 ### Terraform 0.12
 
-To use this provider with Terraform 0.12, you will need to download and install the executable yourself. You can download the latest version from the [releases page](https://github.com/kvrhdn/terraform-provider-honeycombio/releases) or build it directly from source:
+To use this provider with Terraform 0.12, you will need to download and install the executable yourself. You can 
+download the latest version from the [releases page](https://github.com/kvrhdn/terraform-provider-honeycombio/releases) 
+or build it directly from source:
 
 ```sh
 # clone the repository and run:
 go build -o terraform-provider-honeycombio
 ```
 
-Once you have the executable, you can either place it in your working directory (the directory you run `terraform init`) or [install it is a third-party plugin](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins):
+Once you have the executable, you can either place it in your working directory (the directory you run `terraform init`) 
+or [install it is a third-party plugin](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins):
 
 ```sh
 # for Linux and macOS


### PR DESCRIPTION
Update markdown documents to avoid long lines and scrolling making editing easier.